### PR TITLE
Fix to save session when overwrite configuration is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The options can also contain any of the follow (for the full list, see [cookies 
   - `secureProxy`: a boolean indicating whether the cookie is only to be sent over HTTPS (use this if you handle SSL not in your node process).
   - `httpOnly`: a boolean indicating whether the cookie is only to be sent over HTTP(S), and not made available to client JavaScript (`true` by default).
   - `signed`: a boolean indicating whether the cookie is to be signed (`false` by default). If this is true, another cookie of the same name with the `.sig` suffix appended will also be sent, with a 27-byte url-safe base64 SHA1 value representing the hash of _cookie-name_=_cookie-value_ against the first [Keygrip](https://github.com/expressjs/keygrip) key. This signature key is used to detect tampering the next time a cookie is received.
-  - `overwrite`: a boolean indicating whether to overwrite previously set cookies of the same name (`false` by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
+  - `overwrite`: a boolean indicating whether to overwrite previously set cookies of the same name (`true` by default). If this is true, all cookies set during the same request with the same name (regardless of path or domain) are filtered out of the Set-Cookie header when setting this cookie.
 
 ### Destroying a session
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function(opts){
           cookies.set(name, '', opts);
         } else if (!json && !sess.length) {
           // do nothing if new and not populated
-        } else if (sess.changed(json)) {
+        } else if (opts.overwrite || sess.changed(json)) {
           // save
           sess.save();
         }

--- a/test/test.js
+++ b/test/test.js
@@ -222,23 +222,41 @@ describe('Cookie Session', function(){
         .expect(200, done);
       })
 
-      it('should not Set-Cookie', function(done){
-        var app = App();
-        app.use(function (req, res, next) {
-          assert.equal(req.session.message, 'hello');
-          res.end('aklsjdfkljasdf');
-        })
+      describe('when options.overwrite = true', function(){
+        it('should Set-Cookie', function(done){
+          var app = App({overwrite: true});
+          app.use(function (req, res, next) {
+            assert.equal(req.session.message, 'hello');
+            res.end('aklsjdfkljasdf');
+          })
 
-        request(app.listen())
-        .get('/')
-        .set('Cookie', cookie)
-        .expect(200, function(err, res){
-          if (err) return done(err);
-          assert.strictEqual(res.header['set-cookie'], undefined);
-          done();
+          request(app.listen())
+            .get('/')
+            .set('Cookie', cookie)
+            .expect('Set-Cookie', /express:sess/)
+            .expect(200, done)
+          })
         })
       })
-    })
+
+      describe('when options.overwrite = false', function(){
+        it('should not Set-Cookie', function(done){
+          var app = App({overwrite: false});
+          app.use(function (req, res, next) {
+            assert.equal(req.session.message, 'hello');
+            res.end('aklsjdfkljasdf');
+          })
+
+          request(app.listen())
+            .get('/')
+            .set('Cookie', cookie)
+            .expect(200, function(err, res){
+              if (err) return done(err);
+              assert.strictEqual(res.header['set-cookie'], undefined);
+              done();
+            })
+          })
+        })
 
     describe('when accessed and changed', function(){
       it('should Set-Cookie', function(done){


### PR DESCRIPTION
In the current version, if you update maxAge or expires without changing the content of the session, the session cookie does not get resaved with the new expiration.  This fixes that by saving the session when the existing overwrite property is set to true.