### PR TITLE
Add alwaysSetCookie option to update expiration

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
   * Save all enumerable properties on `req.session`
     - Including `_`-prefixed properties
   * perf: reduce the scope of try-catch deopt
+  * Add `alwaysSetCookie` option
 
 1.2.0 / 2015-07-01
 ==================

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ for key rotation.
 
 A string which will be used as single key if `keys` is not provided.
 
+##### alwaysSetCookie
+
+Always set a `Set-Cookie` header on every response, even if no session
+values have been set or changed. This resets the expiration date. The
+default value is `false`.
+
 ##### Cookie Options
 
 Other options are passed to `cookies.get()` and `cookies.set()` allowing you

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function cookieSession(options) {
   if (null == opts.overwrite) opts.overwrite = true;
   if (null == opts.httpOnly) opts.httpOnly = true;
   if (null == opts.signed) opts.signed = true;
+  if (null == opts.alwaysSetCookie) opts.alwaysSetCookie = false;
 
   if (!keys && opts.signed) throw new Error('.keys required.');
 
@@ -97,8 +98,14 @@ function cookieSession(options) {
 
     onHeaders(res, function setHeaders() {
       if (sess === undefined) {
-        // not accessed
-        return;
+        // not accessed - but need to set header anyway, so load session
+        if (opts.alwaysSetCookie) {
+          sess = req.session
+        }
+        // not accessed - don't need to do anything
+        else {
+          return
+        }
       }
 
       try {
@@ -107,6 +114,9 @@ function cookieSession(options) {
           cookies.set(name, '', req.sessionOptions)
         } else if ((!sess.isNew || sess.isPopulated) && sess.isChanged) {
           // save populated or non-new changed session
+          sess.save()
+        }
+        else if (opts.alwaysSetCookie) {
           sess.save()
         }
       } catch (e) {

--- a/test/test.js
+++ b/test/test.js
@@ -135,6 +135,20 @@ describe('Cookie Session', function(){
           done();
         })
       })
+
+      it('should Set-Cookie with alwaysSetCookie', function(done) {
+        var app = App({
+          alwaysSetCookie: true,
+        });
+        app.use(function (req, res, next) {
+          res.end('greetings');
+        })
+
+        request(app.listen())
+        .get('/')
+        .expect('Set-Cookie', /express\.sess/)
+        .expect(200, done);
+      })
     })
 
     describe('when accessed and not populated', function(done){
@@ -152,6 +166,21 @@ describe('Cookie Session', function(){
           assert.strictEqual(res.header['set-cookie'], undefined);
           done();
         })
+      })
+
+      it('should Set-Cookie with alwaysSetCookie', function(done) {
+        var app = App({
+          alwaysSetCookie: true,
+        });
+        app.use(function (req, res, next) {
+          req.session;
+          res.end('greetings');
+        })
+
+        request(app.listen())
+        .get('/')
+        .expect('Set-Cookie', /express\.sess/)
+        .expect(200, done);
       })
     })
 
@@ -207,6 +236,21 @@ describe('Cookie Session', function(){
           done();
         })
       })
+
+      it('should Set-Cookie using alwaysSetCookie', function(done){
+        var app = App({
+          alwaysSetCookie: true,
+        });
+        app.use(function (req, res, next) {
+          res.end('aklsjdfklasjdf');
+        })
+
+        request(app.listen())
+        .get('/')
+        .set('Cookie', cookie)
+        .expect('Set-Cookie', /express\.sess/)
+        .expect(200, done);
+      })
     })
 
     describe('when accessed but not changed', function(){
@@ -238,6 +282,22 @@ describe('Cookie Session', function(){
           assert.strictEqual(res.header['set-cookie'], undefined);
           done();
         })
+      })
+
+      it('should Set-Cookie with alwaysSetCookie', function(done){
+        var app = App({
+          alwaysSetCookie: true,
+        });
+        app.use(function (req, res, next) {
+          assert.equal(req.session.message, 'hello');
+          res.end('aklsjdfkljasdf');
+        })
+
+        request(app.listen())
+        .get('/')
+        .set('Cookie', cookie)
+        .expect('Set-Cookie', /express\.sess/)
+        .expect(200, done);
       })
     })
 


### PR DESCRIPTION
I use *cookie-session* to set a unique id once a session is created and never change the session again. I want the session to expire after 2 weeks from the last time the session was *active*. Currently, because the session is never changed, the session expires 2 weeks after the session was *created*.

This change adds a `alwaysSetCookie` option which causes the cookie to be sent on every response, causing the expiration date to be updated.

This is similar to [*express-session*'s `rolling` option][rolling]. I'm happy to change the option name to `rolling` to conform, but thought `alwaysSetCookie` was a bit more descriptive.

[rolling]: https://github.com/expressjs/session#rolling

Also see https://github.com/senchalabs/connect/issues/670 for more context and use cases for this feature.