### PR TITLE
docs: bind example code to the root path

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ app.use(cookieSession({
   keys: ['key1', 'key2']
 }))
 
-app.use(function (req, res, next) {
+app.get('/', function (req, res, next) {
   // Update views
   req.session.views = (req.session.views || 0) + 1
 


### PR DESCRIPTION
Fix for https://github.com/expressjs/cookie-session/issues/56.

Instead of calling the function on all requests to the app, limit it to the root path, so that the request for favicon.icon in Chrome does not unexpectedly increment the view count by 2.
