### PR TITLE
Adding the next() to express middleware code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ app.use(cookieSession({
 // have a different value than the default.
 app.use(function (req, res, next) {
   req.sessionOptions.maxAge = req.session.maxAge || req.sessionOptions.maxAge
+  next()
 })
 
 // ... your logic here ...

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ app.use(function (req, res, next) {
 Because the entire session object is encoded and stored in a cookie, it is
 possible to exceed the maxium cookie size limits on different browsers. The
 [RFC6265 specification](https://tools.ietf.org/html/rfc6265#section-6.1)
-reccomends that a browser **SHOULD** allow
+recommends that a browser **SHOULD** allow
 
 > At least 4096 bytes per cookie (as measured by the sum of the length of
 > the cookie's name, value, and attributes)


### PR DESCRIPTION
Just updating the README with express `next()` function for middlewares, so anyone trying it can start at something that works.