### PR TITLE
Fix extending cookie expiration example assumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ app.use(cookieSession({
 // Update a value in the cookie so that the set-cookie will be sent.
 // Only changes every minute so that it's not sent with every request.
 app.use(function (req, res, next) {
-  req.session.nowInMinutes = Date.now() / 60e3
+  req.session.nowInMinutes = Math.floor(Date.now() / 60e3)
   next()
 })
 


### PR DESCRIPTION
Date.now() / 60e3 is a value that changes for every request
The example works updating (hence extending) the cookie for every request
without waiting for a minute time increase
We must get an integer value of minutes
see http://stackoverflow.com/questions/4228356/how-to-perform-integer-division-and-get-the-remainder-in-javascript