### PR TITLE
deps: debug@2.6.8

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,10 @@
-unreleased
+2.0.0-beta.2 / 2017-05-23
 ==========
 
   * Create new session for all types of invalid sessions
-  * deps: debug@2.6.3
+  * deps: debug@2.6.8
     - Fix: `DEBUG_MAX_ARRAY_LENGTH`
+    - Fix: vulnerability in ms@>=0.7.1,<=1.0.0, [details](https://snyk.io/vuln/npm:ms:20170412)
 
 2.0.0-beta.1 / 2017-02-19
 ==========================

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cookie-session",
   "description": "cookie session middleware",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"
@@ -16,7 +16,7 @@
   "repository": "expressjs/cookie-session",
   "dependencies": {
     "cookies": "0.7.0",
-    "debug": "2.6.3",
+    "debug": "2.6.8",
     "on-headers": "~1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the vulnerability in ms that's inherited through debug ([details](https://snyk.io/test/npm/cookie-session/2.0.0-beta.1)).

I've also bumped the version of the package in the hope that it'll be released to npm for those using a vulnerable ms in the wild via this package@2.x-beta (as I am). (Sorry, I wasn't sure of the etiquette here, but hopefully it's okay).