### PR TITLE
Fixing bug where opts.secure was not respected.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ function cookieSession(options) {
 
   return function _cookieSession(req, res, next) {
     var cookies = req.sessionCookies = new Cookies(req, res, {
-      keys: keys
+      keys: keys,
+      secure: opts.secure,
     });
     var sess, json;
 


### PR DESCRIPTION
Back in April I ran into a bug with cookie-session where `opts.secure` was not being respected. iirc the cookies always were secure/insecure based on the currently running expressjs server, but I needed the cookie to be secure even though SSL was being terminated at a load balancer in front of my express server.