### PR TITLE
#143 Adds secureProxy to manage SSL proxied apps on no-Express Node servers

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ function cookieSession (options) {
   var name = opts.name || 'session'
 
   // secrets
+  var secureProxy = opts.secureProxy || false;
   var keys = opts.keys
   if (!keys && opts.secret) keys = [opts.secret]
 
@@ -59,7 +60,8 @@ function cookieSession (options) {
 
   return function _cookieSession (req, res, next) {
     var cookies = new Cookies(req, res, {
-      keys: keys
+      keys: keys,
+      secure: secureProxy,
     })
     var sess
 


### PR DESCRIPTION
Hi guys,

I am a user of BlitzJS which uses cookie-session but no actual Express. And I use it behind Nginx SSL proxy.

In order to use cookie-session behind SSL proxy ExpressJS trust proxy feature should be set however for BlitzJS or NextJS frameworks that use cookies-session for authorization, there is no trust proxy.

We discussed the problem with BlitzJS author here and came to the conclusion that forcing secure in cookies constructor (not when setting a cookie, but pass to new Cookies as an option) is a way to go in full accordance to the cookies package author recommendations for the case when SSL is not controlled by NodeJS https://github.com/pillarjs/cookies/blob/master/index.js#L102 https://www.npmjs.com/package/@xyezir/cookies#cookiesset-name--value---options--

I made a PR that adds `secureProxy` option which is crucial for BlitzJS/NextJS users who use cookie-session and want to run an app behind SSL proxy.

Please suggest if this is the best approach to the problem or you see a better one.