### PR TITLE
add connectionSecure flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ change signature parameters like the algorithm of the signature.
 
 A string which will be used as single key if `keys` is not provided.
 
+##### connectionSecure
+
+Flag passed to [cookies module](https://www.npmjs.org/package/cookies#readme), to explicitally specify if the connection is secure.
+
 ##### Cookie Options
 
 Other options are passed to `cookies.get()` and `cookies.set()` allowing you

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = cookieSession
  * @param {object} [options]
  * @param {boolean} [options.httpOnly=true]
  * @param {array} [options.keys]
+ * @param {boolean} [options.connectionSecure]
  * @param {string} [options.name=session] Name of the cookie to use
  * @param {boolean} [options.overwrite=true]
  * @param {string} [options.secret]
@@ -48,6 +49,12 @@ function cookieSession (options) {
   var keys = opts.keys
   if (!keys && opts.secret) keys = [opts.secret]
 
+  // connectionSecure
+  var connectionSecure =
+    typeof opts.connectionSecure === 'boolean'
+      ? opts.connectionSecure
+      : undefined
+
   // defaults
   if (opts.overwrite == null) opts.overwrite = true
   if (opts.httpOnly == null) opts.httpOnly = true
@@ -59,7 +66,8 @@ function cookieSession (options) {
 
   return function _cookieSession (req, res, next) {
     var cookies = new Cookies(req, res, {
-      keys: keys
+      keys: keys,
+      secure: connectionSecure
     })
     var sess
 

--- a/test/test.js
+++ b/test/test.js
@@ -166,6 +166,23 @@ describe('Cookie Session', function () {
           .expect(shouldNotSetCookies())
           .expect(200, done)
       })
+
+      describe('when options.connectionSecure = true', function () {
+        it('should Set-Cookie', function (done) {
+          var app = App({ secure: true, connectionSecure: true })
+          app.use(function (req, res, next) {
+            process.nextTick(function () {
+              req.session.message = 'hello!'
+              res.end('greetings')
+            })
+          })
+
+          request(app)
+            .get('/')
+            .expect(shouldHaveCookie('session'))
+            .expect(200, done)
+        })
+      })
     })
   })
 


### PR DESCRIPTION
## Issue: 

When set `{ secure: true }` flag, the `cookies` module will check and throw exception if the connection is not secure.
https://github.com/pillarjs/cookies/blob/d2111627e8ff2e29f90e75d1f1cc4164c5a07a3f/index.js#L93-L95

In my use case, Node.js is running behind proxy, so `req.protocol` is http. It will block by above condition.

### Fix:
The [cookies](https://github.com/pillarjs/cookies#api) module supports _options.secure_ to explicitly specify if the connection is secure. Adding corresponding flag `connectionSecure` to use


related:
- https://github.com/pillarjs/cookies/issues/51
