### PR TITLE
Enable multiple cookie-sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,11 +61,11 @@ jobs:
 
         - name: Node.js 6.x
           node-version: "6.17"
-          npm-i: mocha@6.2.2 nyc@14.1.1
+          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@3.4.2
 
         - name: Node.js 7.x
           node-version: "7.10"
-          npm-i: mocha@6.2.2 nyc@14.1.1
+          npm-i: mocha@6.2.2 nyc@14.1.1 supertest@3.4.2
 
         - name: Node.js 8.x
           node-version: "8.17"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         echo "node@$(node -v)"
         echo "npm@$(npm -v)"
         npm -s ls ||:
-        (npm -s ls --depth=0 ||:) | awk -F'[ @]' 'NR>1 && $2 { print "::set-output name=" $2 "::" $3 }'
+        (npm -s ls --depth=0 ||:) | awk -F'[ @]' 'NR>1 && $2 { print "$2=$3" >> $GITHUB_OUTPUT }'
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         name:
@@ -102,7 +102,7 @@ jobs:
           node-version: "17.2"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ recommends that a browser **SHOULD** allow
 > the cookie's name, value, and attributes)
 
 In practice this limit differs slightly across browsers. See a list of
-[browser limits here](http://browsercookielimits.squawky.net/). As a rule
+[browser limits here](http://browsercookielimits.iain.guru). As a rule
 of thumb **don't exceed 4093 bytes per domain**.
 
 If your session object is large enough to exceed a browser limit when encoded,

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ you have identifying information to store for the session.
 If the session contents change rarely, you may wish to intervene to prolong
 sessions, as described [below](#extending-the-session-expiration).
 
-This middleware can be used multiple times to create several cookie-sessions.
+You can create multiple cookie-sessions by passing multiple [options](#options)
+objects to `cookieSession`.
 But note that their [`names`](#name), as well as their
 [`sessionNames`](#sessionname), must be distinct.
 
@@ -311,14 +312,12 @@ var express = require('express')
 
 var app = express()
 
-// One cookie not available to client-side JS
 app.use(cookieSession({
+  // One cookie not available to client-side JS
   // name & sessionName default to 'session'
   secret: 'topSecret'
-}))
-
-// Another cookie. This one can be accessed by client-side JS.
-app.use(cookieSession({
+}, {
+  // Another cookie. This one can be accessed by client-side JS.
   name: 'insecureSession',
   sessionName: 'insecureSession',
   httpOnly: false,

--- a/README.md
+++ b/README.md
@@ -56,10 +56,16 @@ the loaded session. This session is either a new session if no valid session was
 provided in the request, or a loaded session from the request.
 
 The middleware will automatically add a `Set-Cookie` header to the response if the
-contents of `req.session` were altered. _Note_ that no `Set-Cookie` header will be
+contents of the session were altered. _Note_ that no `Set-Cookie` header will be
 in the response (and thus no session created for a specific user) unless there are
 contents in the session, so be sure to add something to `req.session` as soon as
 you have identifying information to store for the session.
+If the session contents change rarely, you may wish to intervene to prolong
+sessions, as described [below](#extending-the-session-expiration).
+
+This middleware can be used multiple times to create several cookie-sessions.
+But note that their [`names`](#name), as well as their
+[`sessionNames`](#sessionname), must be distinct.
 
 #### Options
 
@@ -68,6 +74,27 @@ Cookie session accepts these properties in the options object.
 ##### name
 
 The name of the cookie to set, defaults to `session`.
+If you are using multiple cookie-sessions, give each a unique `name`.
+
+##### sessionName
+
+The name of the session.
+Defaults to `"session"`.
+
+To avoid confusion, it is sensible to choose the same value as [`name`](#name).
+
+Sessions with the default name will be accessible at `req.session`, and their
+[options](#reqsessionoptions) will be accessible at `req.sessionOptions`.
+
+The session data will always be accessible on the `req.sessions` object, at the
+property matching your sessionName.
+e.g. for sessionName `"foo"`, you can access the session at `req.sessions.foo`.
+
+Similarly, the [options](#reqsessionoptions) for each session will always be
+accessible on the `req.sessionsOptions` object.
+E.g. `"foo"`'s options will be at `req.sessionsOptions.foo`.
+
+To create multiple cookie-sessions, give each a unique `sessionName`.
 
 ##### keys
 
@@ -99,29 +126,26 @@ The options can also contain any of the following (for the full list, see
   - `signed`: a boolean indicating whether the cookie is to be signed (`true` by default).
   - `overwrite`: a boolean indicating whether to overwrite previously set cookies of the same name (`true` by default).
 
-### req.session
+### Accessing sessions
 
-Represents the session for the given request.
+Session data can always be accessed via the property on[
+`req.sessions`](#reqsessions) matching their [sessionName](#sessionname).
+Sessions with the default [sessionName](#sessionname), `"session"`, can also be
+accessed at [`req.session`](#reqsession).
 
-#### .isChanged
+#### req.session
 
-Is `true` if the session has been changed during the request.
+The session data for the session with [sessionName](#sessionname) "session" (the
+default). `undefined` if there is no session with [sessionName](#sessionname)
+"session".
 
-#### .isNew
+#### req.sessions
 
-Is `true` if the session is new.
+Provides access to the data for all sessions, keyed by their
+[sessionName](#sessionname).
+E.g. for sessionName `"foo"`, you can access the session at `req.sessions.foo`.
 
-#### .isPopulated
-
-Determine if the session has been populated with data or is empty.
-
-### req.sessionOptions
-
-Represents the session options for the current request. These options are a
-shallow clone of what was provided at middleware construction and can be
-altered to change cookie setting behavior on a per-request basis.
-
-### Destroying a session
+#### Destroying a session
 
 To destroy a session simply set it to `null`:
 
@@ -129,13 +153,53 @@ To destroy a session simply set it to `null`:
 req.session = null
 ```
 
-### Saving a session
+#### Saving a session
 
 Since the entire contents of the session is kept in a client-side cookie, the
 session is "saved" by writing a cookie out in a `Set-Cookie` response header.
 This is done automatically if there has been a change made to the session when
 the Node.js response headers are being written to the client and the session
 was not destroyed.
+
+#### Session properties
+
+Sessions always have the following properties, in addition to any you define:
+
+##### .isChanged
+
+Is `true` if the session has been changed during the request.
+
+##### .isNew
+
+Is `true` if the session is new.
+
+##### .isPopulated
+
+Determine if the session has been populated with data or is empty.
+
+#### Session options
+
+These options inherit from the options provided at middleware construction and
+can be altered to change cookie setting behavior on a per-request basis.
+
+The options for each session can always be accessed via the property on
+[`req.sessionsOptions`](#reqsessionsoptions) matching their
+[sessionName](#sessionname).
+Sessions with the default [sessionName](#sessionname), `"session"`, can also be
+accessed at [`req.sessionOptions`](#reqsession).
+
+##### req.sessionOptions
+
+The session options for the session with [sessionName](#sessionname) `"session"`
+(the default).
+`undefined` if there is no session with [sessionName](#sessionname) `"session"`.
+
+##### req.sessionsOptions
+
+Provides access to the options for all sessions, keyed by their
+[sessionName](#sessionname).
+E.g. for sessionName `"foo"`, you can access the session options at
+`req.sessionsOptions.foo`.
 
 ## Examples
 
@@ -236,6 +300,44 @@ app.use(cookieSession({
 }))
 
 // ... your logic here ...
+```
+
+### Setting multiple cookies
+This example sets a session cookie that the server can trust, and an insecure
+session cookie that is just used to make some metadata available to the client.
+```js
+var cookieSession = require('cookie-session')
+var express = require('express')
+
+var app = express()
+
+// One cookie not available to client-side JS
+app.use(cookieSession({
+  // name & sessionName default to 'session'
+  secret: 'topSecret'
+}))
+
+// Another cookie. This one can be accessed by client-side JS.
+app.use(cookieSession({
+  name: 'insecureSession',
+  sessionName: 'insecureSession',
+  httpOnly: false,
+  signed: false
+}))
+
+app.get('/', function (req, res, next) {
+  // Set secure session data
+  req.session.signedStuff ||= "shibboleth"
+  // Update insecure session data. (This is just an FYI for the client. The
+  // server must not trust it to authenticate users!)
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60e3)
+  req.sessions.insecureSession.sessionExpiry = tomorrow
+  next()
+})
+
+// ... your logic here ...
+
+app.listen(3000)
 ```
 
 ## Usage Limitations

--- a/package.json
+++ b/package.json
@@ -22,16 +22,16 @@
   },
   "devDependencies": {
     "connect": "3.7.0",
-    "eslint": "7.32.0",
-    "eslint-config-standard": "14.1.1",
-    "eslint-plugin-import": "2.25.3",
-    "eslint-plugin-markdown": "2.2.1",
+    "eslint": "8.30.0",
+    "eslint-config-standard": "17.0.0",
+    "eslint-plugin-import": "2.26.0",
+    "eslint-plugin-markdown": "3.0.0",
     "eslint-plugin-node": "11.1.0",
-    "eslint-plugin-promise": "5.2.0",
+    "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-standard": "4.1.0",
-    "mocha": "9.1.3",
+    "mocha": "10.2.0",
     "nyc": "15.1.0",
-    "supertest": "6.1.6"
+    "supertest": "6.3.0"
   },
   "files": [
     "HISTORY.md",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "repository": "expressjs/cookie-session",
   "dependencies": {
+    "array-flatten": "1.1.1",
     "cookies": "0.8.0",
     "debug": "3.2.7",
     "on-headers": "~1.0.2",

--- a/test/test.js
+++ b/test/test.js
@@ -162,6 +162,21 @@ describe('Cookie Session', function () {
     })
   })
 
+  describe('when two cookies are configured with the same name', function () {
+    it("should error if the cookies have the same name", function (done) {
+      assert.throws(function() {
+        App({}, {sessionName: 'secondary'})
+      })
+      done()
+    })
+    it("should error if the cookies have the same SessionName", function (done) {
+      assert.throws(function() {
+        App({}, {name: 'secondary'})
+      })
+      done()
+    })
+  })
+
   describe('when multiple cookieSessions are required', function () {
     var app
     it("multiple configs to be passed to cookieSession in an array", function () {
@@ -615,17 +630,19 @@ describe('Cookie Session', function () {
 
 /**
  * Connect to an app using cookie-sessions with passed configurations
- * @param {...object} configurations
+ * @param {...Configuration} configurations
  * @return {app}
  */
 function App (configurations) {
   var app = connect()
   var configs = arguments.length ? Array.prototype.slice.call(arguments) : [{}]
-  configs.forEach(function addKeyBasedSession(configuration) {
-    var config = Object.create(configuration)
-    config.keys = ['a', 'b']
-    app.use(session(config))
+  var keyedConfigs = configs.map(function addKeys(configuration) {
+    return Object.create(configuration, { keys: {
+      value: ['a', 'b'],
+      enumerable: true,
+    }})
   })
+  app.use(session(keyedConfigs))
   return app
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+'use strict'
 
 process.env.NODE_ENV = 'test'
 
@@ -10,7 +11,7 @@ describe('Cookie Session', function () {
   describe('"httpOnly" option', function () {
     it('should default to "true"', function (done) {
       var app = App()
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         req.session.message = 'hi'
         res.end(String(req.sessionOptions.httpOnly))
       })
@@ -23,7 +24,7 @@ describe('Cookie Session', function () {
 
     it('should use given "false"', function (done) {
       var app = App({ httpOnly: false })
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         req.session.message = 'hi'
         res.end(String(req.sessionOptions.httpOnly))
       })
@@ -38,7 +39,7 @@ describe('Cookie Session', function () {
   describe('"overwrite" option', function () {
     it('should default to "true"', function (done) {
       var app = App()
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         res.setHeader('Set-Cookie', [
           'session=foo; path=/fake',
           'foo=bar'
@@ -55,7 +56,7 @@ describe('Cookie Session', function () {
 
     it('should use given "false"', function (done) {
       var app = App({ overwrite: false })
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         res.setHeader('Set-Cookie', [
           'session=foo; path=/fake',
           'foo=bar'
@@ -73,9 +74,9 @@ describe('Cookie Session', function () {
   })
 
   describe('when options.name = my.session', function () {
-    it('should use my.session for cookie name', function (done) {
+    it("should use 'my.session' for cookie name, but 'session' for session name", function (done) {
       var app = App({ name: 'my.session' })
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         req.session.message = 'hi'
         res.end()
       })
@@ -87,6 +88,123 @@ describe('Cookie Session', function () {
     })
   })
 
+  describe('when options.sessionName = my.session', function () {
+    it("the default-named cookie should be accessible at req.session", function (done) {
+      var app = App(
+        {}, // default name 'session' should be used
+        {
+          name: "secondary",
+          sessionName: "secondary",
+        }
+      )
+      app.use(function (req, res, next) {
+        req.sessions.session.number = 1
+        req.sessions.secondary.number = 2
+        next()
+      })
+      app.use(function (req, res, _next) {
+        res.end(String(req.session.number))
+      })
+
+      request(app)
+        .get('/')
+        .expect(200, '1', done)
+    })
+
+    it("the session should be at req.sessions['my.session'] but not req.session", function (done) {
+      var app = App({ sessionName: 'my.session' })
+      app.use(function (req, res, _next) {
+        req.sessions['my.session'].message = 'hi'
+        res.end(String(req.session))
+      })
+
+      request(app)
+        .get('/')
+        .expect(shouldHaveCookie('session'))
+        .expect(200, 'undefined', done)
+    })
+
+    it("should use 'my.session' as the session name, but 'session' as the cookie name", function (done) {
+      var app = App({ sessionName: 'my.session' })
+      app.use(function (req, res, _next) {
+        req.sessions['my.session'].message = 'hi'
+        res.end()
+      })
+
+      request(app)
+        .get('/')
+        .expect(shouldHaveCookie('session'))
+        .expect(200, done)
+    })
+  })
+
+  describe('when two cookies are used with different options', function () {
+    it("should set the 'httpOnly' but not the 'jsAlso' cookie-session as httpOnly", function (done) {
+      var app = App({
+        name: 'httpOnly',
+        sessionName: 'httpOnly',
+      }, {
+        name: 'jsAlso',
+        sessionName: 'jsAlso',
+        httpOnly: false,
+      })
+      app.use(function (req, res, _next) {
+        req.sessions.httpOnly.message = 'httpOnly'
+        req.sessions.jsAlso.message = 'jsAlso'
+        res.end()
+      })
+
+      request(app)
+        .get('/')
+        .expect(shouldHaveCookieWithParameter('httpOnly', 'httpOnly'))
+        .expect(shouldHaveCookieWithoutParameter('jsAlso', 'httpOnly'))
+        .expect(200, done)
+    })
+  })
+
+  describe('when multiple cookieSessions are required', function () {
+    var app
+    it("multiple configs to be passed to cookieSession in an array", function () {
+      app = connect()
+      app.use(session([
+        {
+          signed: false,
+        }, {
+          signed: false,
+          name: 'secondary',
+          sessionName: 'secondary',
+        }
+      ]))
+    })
+    it("cookieSession can be called multiple times", function () {
+      app = connect()
+      app.use(session({
+        signed: false,
+      }))
+      app.use(session({
+        signed: false,
+        name: 'secondary',
+        sessionName: 'secondary',
+      }))
+    })
+    afterEach(function (done) {
+      app.use(function (req, _res, next) {
+        req.session.name = req.sessionOptions.name
+        req.sessions.secondary.name = req.sessionsOptions.secondary.name
+        next()
+      })
+      app.use('/', function (req, res, _next) {
+        res.end(req.session.name + req.sessions.secondary.name)
+      })
+
+      request(app)
+        .get('/')
+        .expect(shouldHaveCookie('session'))
+        .expect(shouldHaveCookie('secondary'))
+        .expect(200, 'sessionsecondary', done)
+    })
+  })
+
   describe('when options.signed = true', function () {
     describe('when options.keys are set', function () {
       it('should work', function (done) {
@@ -94,7 +212,7 @@ describe('Cookie Session', function () {
         app.use(session({
           keys: ['a', 'b']
         }))
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session.message = 'hi'
           res.end()
         })
@@ -111,7 +229,7 @@ describe('Cookie Session', function () {
         app.use(session({
           secret: 'a'
         }))
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session.message = 'hi'
           res.end()
         })
@@ -138,7 +256,7 @@ describe('Cookie Session', function () {
         app.use(session({
           signed: false
         }))
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session.message = 'hi'
           res.end()
         })
@@ -154,7 +272,7 @@ describe('Cookie Session', function () {
     describe('when connection not secured', function () {
       it('should not Set-Cookie', function (done) {
         var app = App({ secure: true })
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           process.nextTick(function () {
             req.session.message = 'hello!'
             res.end('greetings')
@@ -172,7 +290,7 @@ describe('Cookie Session', function () {
   describe('when the session contains a ;', function () {
     it('should still work', function (done) {
       var app = App()
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         if (req.method === 'POST') {
           req.session.string = ';'
           res.statusCode = 204
@@ -198,7 +316,7 @@ describe('Cookie Session', function () {
   describe('when the session is invalid', function () {
     it('should create new session', function (done) {
       var app = App({ name: 'my.session', signed: false })
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         res.end(String(req.session.isNew))
       })
 
@@ -213,7 +331,7 @@ describe('Cookie Session', function () {
     describe('when not accessed', function () {
       it('should not Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           res.end('greetings')
         })
 
@@ -224,10 +342,10 @@ describe('Cookie Session', function () {
       })
     })
 
-    describe('when accessed and not populated', function (done) {
+    describe('when accessed and not populated', function () {
       it('should not Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           var sess = req.session
           res.end(JSON.stringify(sess))
         })
@@ -239,10 +357,10 @@ describe('Cookie Session', function () {
       })
     })
 
-    describe('when populated', function (done) {
+    describe('when populated', function () {
       it('should Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session.message = 'hello'
           res.end()
         })
@@ -260,7 +378,7 @@ describe('Cookie Session', function () {
 
     before(function (done) {
       var app = App()
-      app.use(function (req, res, next) {
+      app.use(function (req, res, _next) {
         req.session.message = 'hello'
         res.end()
       })
@@ -278,7 +396,7 @@ describe('Cookie Session', function () {
     describe('when not accessed', function () {
       it('should not Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           res.end('aklsjdfklasjdf')
         })
 
@@ -293,7 +411,7 @@ describe('Cookie Session', function () {
     describe('when accessed but not changed', function () {
       it('should be the same session', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           assert.strictEqual(req.session.message, 'hello')
           res.end('aklsjdfkljasdf')
         })
@@ -306,7 +424,7 @@ describe('Cookie Session', function () {
 
       it('should not Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           assert.strictEqual(req.session.message, 'hello')
           res.end('aklsjdfkljasdf')
         })
@@ -322,7 +440,7 @@ describe('Cookie Session', function () {
     describe('when accessed and changed', function () {
       it('should Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session.money = '$$$'
           res.end('klajsdlkfjadsf')
         })
@@ -340,7 +458,7 @@ describe('Cookie Session', function () {
     describe('null', function () {
       it('should expire the session', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session = null
           res.end('lkajsdf')
         })
@@ -353,7 +471,7 @@ describe('Cookie Session', function () {
 
       it('should no longer return a session', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session = null
           res.end(JSON.stringify(req.session))
         })
@@ -368,7 +486,7 @@ describe('Cookie Session', function () {
     describe('{}', function () {
       it('should not Set-Cookie', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session = {}
           res.end('hello, world')
         })
@@ -383,7 +501,7 @@ describe('Cookie Session', function () {
     describe('{a: b}', function () {
       it('should create a session', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session = { message: 'hello' }
           res.end('klajsdfasdf')
         })
@@ -398,7 +516,7 @@ describe('Cookie Session', function () {
     describe('anything else', function () {
       it('should throw', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session = 'aklsdjfasdf'
         })
 
@@ -413,7 +531,7 @@ describe('Cookie Session', function () {
     describe('.isPopulated', function () {
       it('should be false on new session', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           res.end(String(req.session.isPopulated))
         })
 
@@ -424,7 +542,7 @@ describe('Cookie Session', function () {
 
       it('should be true after adding property', function (done) {
         var app = App()
-        app.use(function (req, res, next) {
+        app.use(function (req, res, _next) {
           req.session.message = 'hello!'
           res.end(String(req.session.isPopulated))
         })
@@ -436,21 +554,43 @@ describe('Cookie Session', function () {
     })
   })
 
-  describe('req.sessionOptions', function () {
-    it('should be the session options', function (done) {
-      var app = App({ name: 'my.session' })
-      app.use(function (req, res, next) {
+  describe('session options', function () {
+    it('should be at sessionOptions by default', function (done) {
+      var app = App()
+      app.use(function (req, res, _next) {
         res.end(String(req.sessionOptions.name))
       })
 
       request(app)
         .get('/')
-        .expect(200, 'my.session', done)
+        .expect(200, 'session', done)
+    })
+
+    it('should also be in sessionsOptions[sessionName]', function (done) {
+      var app = App()
+      app.use(function (req, res, _next) {
+        res.end(String(req.sessionsOptions.session.name))
+      })
+
+      request(app)
+        .get('/')
+        .expect(200, 'session', done)
+    })
+
+    it('should not be at sessionOptions for non-default sessionName', function (done) {
+      var app = App({ sessionName: 'foo' })
+      app.use(function (req, res, _next) {
+        res.end(String(req.sessionOptions))
+      })
+
+      request(app)
+        .get('/')
+        .expect(200, 'undefined', done)
     })
 
     it('should alter the cookie setting', function (done) {
-      var app = App({ maxAge: 3600000, name: 'my.session' })
-      app.use(function (req, res, next) {
+      var app = App({ maxAge: 3600000 })
+      app.use(function (req, res, _next) {
         if (req.url === '/max') {
           req.sessionOptions.maxAge = 6500000
         }
@@ -461,23 +601,31 @@ describe('Cookie Session', function () {
 
       request(app)
         .get('/')
-        .expect(shouldHaveCookieWithTTLBetween('my.session', 0, 3600000))
+        .expect(shouldHaveCookieWithTTLBetween('session', 0, 3600000))
         .expect(200, function (err) {
           if (err) return done(err)
           request(app)
             .get('/max')
-            .expect(shouldHaveCookieWithTTLBetween('my.session', 5000000, Infinity))
+            .expect(shouldHaveCookieWithTTLBetween('session', 5000000, Infinity))
             .expect(200, done)
         })
     })
   })
 })
 
-function App (options) {
-  var opts = Object.create(options || null)
-  opts.keys = ['a', 'b']
+/**
+ * Connect to an app using cookie-sessions with passed configurations
+ * @param {...object} configurations
+ * @return {app}
+ */
+function App (configurations) {
   var app = connect()
-  app.use(session(opts))
+  var configs = arguments.length ? Array.prototype.slice.call(arguments) : [{}]
+  configs.forEach(function addKeyBasedSession(configuration) {
+    var config = Object.create(configuration)
+    config.keys = ['a', 'b']
+    app.use(session(config))
+  })
   return app
 }
 


### PR DESCRIPTION
Enables the user to create arbitrarily many cookie-sessions, whose options can differ. The API design was motivated by ensuring backwards compatibility with v2 (more details in the Discussion below).

Fixes:
- #149
- #170 (because why not?)

The new features are pretty comprehensively tested, and I'm using them in production. But I'm still happy to discuss alternative APIs/implementations. I've also got a sister fork of Definitely Typed with updated typings. I'll create a PR there when this  gets merged.

I'm requesting to merge into master because I noticed that you have some WIP changes on develop.

## Example
A fairly complex example taken from the new tests to illustrate the new features:
```js
app = connect()
app.use(session([
  {
    signed: false,
  }, {
    signed: false,
    name: 'secondary',
    sessionName: 'secondary',
  }
]))
app.use(function (req, _res, next) {
  req.session.name = req.sessionOptions.name
  req.sessions.secondary.name = req.sessionsOptions.secondary.name
  next()
})
app.use('/', function (req, res, _next) {
  res.end(req.session.name + req.sessions.secondary.name)
})

request(app)
  .get('/')
  .expect(shouldHaveCookie('session'))
  .expect(shouldHaveCookie('secondary'))
  .expect(200, 'sessionsecondary', done)
})
```

## Discussion
I tend to discuss the "why", including rejected alternative designs, in my commit messages. But I've basically reproduced that commentary here for convenience.

### Enable setting multiple cookie-sessions
Introduces a new option, 'sessionName', which is the key under `Express.Request.sessions` where the session can be accessed. 'session' is the default sessionName, and sessions with sessionName 'session' are still accessible at `Express.Request.session`. This API was chosen to avoid breaking existing applications.

Rejected alternative APIs:
- The `name` property acts as the session accessor on `req.sessions`. Either obviating the need for the `sessionName` option, or perhaps allowing the `sessionName` to default to `name`. This would be a breaking change in all apps that provide a non-default value for `name`. I considered working around this by always making the first cookie-session created the one accessible at `req.session`, but this felt hacky and potentially confusing.
- Each session is accessed by adding its sessionName as a property on `req`. I feared this would pollute the namespace, risking name collisions with other modules.

### Call cookieSession with multiple options objects
Users can now pass several, or an array of, options objects to `cookieSession`. One middleware function will always be returned that creates all the sessions. This means that users using multiple cookie-sessions in their app never need to call `cookieSession` multiple times. `cookieSession` now also checks that the sessions have unique names and sessionNames to avoid tricky overwriting bugs.

I rejected an alternative approach, in which `cookieSession` returns an array of middleware functions. You can pass Express an array of middleware exactly like passing a single functions, so it wouldn't break any user's apps in those cases. But we can't assume that all users are passing the function straight to Express.
