### PR TITLE
Forward opts.secure to the `cookies` library to prevent silent error

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,8 @@ function cookieSession (options) {
 
   return function _cookieSession (req, res, next) {
     var cookies = new Cookies(req, res, {
-      keys: keys
+      keys: keys,
+      secure: opts.secure
     })
     var sess
 


### PR DESCRIPTION
If express thinks you are running over an unsecure connection, like when X-Forwarded-Proto is http, cookie-session will silently fail to set the session cookie (unless debugging is turned on)

This PR forwards options.secure to the `cookies` library.

I accidentally changed how my NGINX sends x-forwarded-* headers ,and even though it was running behind HTTPS, nginx would send the X-Forwared-Proto: http header and sessions on my site would start to fail completely, resuting in a big outage for users.


Code that fails

```js
Cookies.prototype.set = function(name, value, opts) {
  // ...
  var secure = this.secure === undefined
    ? req.protocol === 'https' || isRequestEncrypted(req)
    : Boolean(this.secure)

  // ...

  if (!secure && opts && opts.secure) {
    throw new Error('Cannot send secure cookie over unencrypted connection')
  }
```